### PR TITLE
Don't NPE trying to get config variables if there is no config

### DIFF
--- a/CascLib/CASCConfig.cs
+++ b/CascLib/CASCConfig.cs
@@ -460,6 +460,7 @@ namespace CASCLib
 
         private static string GetConfigVariable(VerBarConfig config, string filterParamName, string filterParamValue, string varName)
         {
+            if (config == null) return null;
             if (config.Count == 1 || !HasConfigVariable(config, filterParamName))
             {
                 if (config[0].TryGetValue(varName, out string varValue))


### PR DESCRIPTION
Fixes null reference in CASCConfig.GetConfigVariable if config parameter is null.

Fixes #7 